### PR TITLE
Fix Streamlit model discovery for default PyTorch model filename

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ MODEL_BASE = "BirdNET+_V3.0-preview3_Global_11K"
 # Available model variants (format: (display_name, extension, framework))
 # Note: INT8 removed due to unreliable results with 11K-class softmax
 MODEL_VARIANTS = [
-    ("FP32 (PyTorch)", ".pt", "pytorch"),
+    ("FP32 (PyTorch)", "_FP32.pt", "pytorch"),
     ("FP32 (ONNX)", "_FP32.onnx", "onnx"),
     ("FP16 (ONNX)", "_FP16.onnx", "onnx"),
 ]


### PR DESCRIPTION
# Fix Streamlit model discovery for default PyTorch model filename

## Summary
This PR fixes a model discovery mismatch in the Streamlit app.

The app expected the PyTorch model filename to end with `.pt`, while the default downloaded model from `analyze.py` is named with the `_FP32.pt` suffix.
As a result, the UI incorrectly showed:

> "No models found. Run analyze.py first to download the default model."

## Change
- Updated the PyTorch entry in [app.py](app.py) model variants from `.pt` to `_FP32.pt`.

## Result
- The default downloaded model (`BirdNET+_V3.0-preview3_Global_11K_FP32.pt`) is now detected correctly.
- The false "No models found" warning is resolved.

## Validation
- Confirmed model file exists in the `models/` directory.
- Confirmed no new diagnostics/errors in [app.py](app.py).
